### PR TITLE
fix: update CVE-2025-5683

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,12 @@
-qtimageformats-opensource-src (5.15.8-1+dde) UNRELEASED; urgency=medium
+qtimageformats-opensource-src (5.15.8-2deepin1) unstable; urgency=medium
 
+  [ Lu YaNing ]
   * New upstream release (5.15.8).
 
- -- Lu YaNing <luyaning@uniontech.com>  Mon, 30 Jan 2023 11:17:11 +0800
+  [ Tian ShiLin ]
+  * update CVE-2025-5683
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Mon, 22 Dec 2025 13:13:52 +0800
 
 qtimageformats-opensource-src (5.15.7-1+dde) unstable; urgency=medium
 

--- a/debian/patches/Fix-validation-issue-for-ICNS-image.patch
+++ b/debian/patches/Fix-validation-issue-for-ICNS-image.patch
@@ -1,0 +1,28 @@
+Description: Fix validation issue for ICNS image
+ The header validation logic could trigger an assert when an invalid ICNS
+ image was loaded. This patch fixes the validation logic.
+ .
+ Credit to OSS-Fuzz
+ .
+ Backported from Qt6.
+Origin: upstream, https://codereview.qt-project.org/c/qt/qtimageformats/+/638666
+Bug: https://bugreports.qt.io/browse/QTBUG-136707
+Last-Update: 2025-12-22
+
+--- a/src/plugins/imageformats/icns/qicnshandler.cpp
++++ b/src/plugins/imageformats/icns/qicnshandler.cpp
+@@ -359,8 +359,11 @@ static inline bool isPowOf2OrDividesBy16
+ 
+ static inline bool isBlockHeaderValid(const ICNSBlockHeader &header, quint64 bound = 0)
+ {
+-    return header.ostype != 0 && (bound == 0
+-                || qBound(quint64(ICNSBlockHeaderSize), quint64(header.length), bound) == header.length);
++    return header.ostype != 0 &&
++        (bound == 0 ||
++            // qBound can be used but requires checking the limits first
++            // this requires less operations
++            (ICNSBlockHeaderSize <= header.length && header.length <= bound));
+ }
+ 
+ static inline bool isIconCompressed(const ICNSEntry &icon)
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,2 @@
+Fix-validation-issue-for-ICNS-image.patch
+


### PR DESCRIPTION
log: The header validation logic could trigger an assert when an invalid ICNS image was loaded. This patch fixes the validation logic.

Credit to OSS-Fuzz

upsteam: https://codereview.qt-project.org/c/qt/qtimageformats/+/644548

第二处改动：
Qt5 版本没有传递第二个 bound 参数，所以这处修改不适用。那是 Qt6 后来增强的验证逻辑，Qt5 中根本没有这段代码，所以仅迁移第一段。